### PR TITLE
Fix: Enable mobile scrolling for profile and settings pages

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -97,7 +97,7 @@ const ProfilePage: React.FC = () => {
 
   // Original page content follows if user is authenticated
   return (
-    <div className="container mx-auto py-8 px-4 sm:px-6 lg:px-8 max-w-2xl">
+    <div className="container mx-auto py-8 px-4 sm:px-6 lg:px-8 max-w-2xl min-h-screen overflow-y-auto pb-16">
       <div className="bg-white shadow-xl rounded-lg p-6 sm:p-8">
         <div className="flex flex-col items-center sm:flex-row sm:items-start mb-8">
           <div className="relative group mb-4 sm:mb-0 sm:mr-6">

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -39,7 +39,7 @@ const SettingsPage: React.FC = () => {
 
   // Original page content follows if user is authenticated
   return (
-    <div className="container mx-auto py-8 px-4 sm:px-6 lg:px-8 max-w-2xl">
+    <div className="container mx-auto py-8 px-4 sm:px-6 lg:px-8 max-w-2xl min-h-screen overflow-y-auto pb-16">
       <div className="bg-white shadow-xl rounded-lg p-6 sm:p-8">
         <div className="flex items-center mb-6">
           <SettingsIcon className="h-8 w-8 text-green-600 mr-3" />


### PR DESCRIPTION
The profile and settings pages were not scrollable on mobile devices if the content exceeded the viewport height.

This commit addresses the issue by:
- Adding `min-h-screen` to ensure the page container can fill the screen height.
- Adding `overflow-y-auto` to the main container div of both `profile/page.tsx` and `settings/page.tsx` to allow vertical scrolling when content overflows.
- Adding `pb-16` (padding-bottom) to provide spacing at the bottom of the page, preventing content from being obscured by mobile browser UI.

The global CSS was also checked, and no conflicting styles were found. You have confirmed that the pages now scroll as expected on mobile devices.